### PR TITLE
Human-readable integrated rates by species file

### DIFF
--- a/PHOTOCHEM/SUBROUTINES/Output.f
+++ b/PHOTOCHEM/SUBROUTINES/Output.f
@@ -891,6 +891,32 @@ c-mc - three lines below should be cut - perhaps usable for JSO2
   191 FORMAT(9X,"1",9X,"2",9X,"3",9X,"4",9X,"5",9X,"6",9X,"7",9X,
      2    "8",9X,"9",8X,"10")
 
+CSH - the following code is taken from the Kasting group's version to
+C   - print out P&L tables with integrated rxn rates, "int.rates.out.dat"
+C   - Jan 9th, 2017
+      DO 702 I=1,NSP
+         WRITE(15,703) ISPEC(I),TP(I)
+ 703     FORMAT(/A8,12X,'PRODUCTION RXS',14X,'INT RX RATE',4X,
+     2      'TP = ',1PE9.2)
+       DO 704 NN=1,NR
+          IF(JCHEM(3,NN).EQ.I .OR. JCHEM(4,NN).EQ.I .OR.
+     2       JCHEM(5,NN).EQ.I)THEN
+        IF(RAT(NN).NE.0.) WRITE(15,705) NN,(CHEMJ(J,NN),J=1,5),RAT(NN)
+ 705       FORMAT(1X,I3,1H),1X,A7,3H + ,A7,3H = ,A7,3H + ,A6,2X,A4,
+     2      1PE10.3)
+          ENDIF
+ 704   CONTINUE
+C
+         WRITE(15,706) ISPEC(I),TL(I)
+ 706     FORMAT(/A8,15X,'LOSS RXS',16X,'INT RX RATE',4X,'TL = ',1PE9.2)
+       DO 707 NN=1,NR
+          IF(JCHEM(1,NN).EQ.I .OR. JCHEM(2,NN).EQ.I)THEN
+        IF(RAT(NN).NE.0.) WRITE(15,705) NN,(CHEMJ(J,NN),J=1,5),RAT(NN)
+          ENDIF
+ 707   CONTINUE
+ 702  CONTINUE
+CSH
+
 c-mc
 c-mc write out loop of NR
 

--- a/PhotoMain.f
+++ b/PhotoMain.f
@@ -537,6 +537,7 @@ C - Seperating the out.dist file into seperate files
        open(66, file='PHOTOCHEM/OUTPUT/out.strctr', status='UNKNOWN')
        open(71, file='PHOTOCHEM/OUTPUT/out.aersol', status='UNKNOWN')
        open(72, file='PHOTOCHEM/OUTPUT/out.tridag', status='UNKNOWN')
+       open(15, file='PHOTOCHEM/OUTPUT/out.HR.rates', status='UNKNOWN')
 
 
 C - other model parameters read in from input_photochem.dat


### PR DESCRIPTION
Incorporated a human-readable integrated rates by species file (PHOTOCHEM/OUTPUT/out.HR.rates) borrowed from the Kasting group
code. This iterates through the long-lived species list and the
reaction list to compile all the integrated rates associated with
the production and loss pathways for each species.